### PR TITLE
Remove reference to 20.09 channel

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -244,11 +244,11 @@
             <div class="install-instructions-container">
               <p>
                 Install
-                <a href="https://search.nixos.org/packages?query=sublime-music&channel=20.09"
+                <a href="https://search.nixos.org/packages?query=sublime-music"
                    target="_blank">
                   <code>sublime-music</code>
                 </a>
-                from the <code>20.09</code> channel.
+                from the <code>stable</code> channel.
               </p>
             </div>
             <pre>nix-env -iA nixpkgs.sublime-music</pre>


### PR DESCRIPTION
Without mentioning the channel, the link will always point to the current stable :)